### PR TITLE
Adjust new logo size

### DIFF
--- a/resources/skins/Default/1080i/get_sources.xml
+++ b/resources/skins/Default/1080i/get_sources.xml
@@ -159,7 +159,7 @@
         <control type="image" id="1001">
             <top>-250</top>
             <left>700</left>
-            <width>150</width>
+            <width>100</width>
             <aspectratio>keep</aspectratio>
             <texture>$INFO[Window().Property(seren.logo)]</texture>
         </control>

--- a/resources/skins/Default/1080i/persistent_background.xml
+++ b/resources/skins/Default/1080i/persistent_background.xml
@@ -159,7 +159,7 @@
         <control type="image" id="1001">
             <top>-250</top>
             <left>700</left>
-            <width>150</width>
+            <width>100</width>
             <aspectratio>keep</aspectratio>
             <texture>$INFO[Window().Property(seren.logo)]</texture>
         </control>

--- a/resources/skins/Default/1080i/resolver.xml
+++ b/resources/skins/Default/1080i/resolver.xml
@@ -82,7 +82,7 @@
         <control type="image" id="1001">
             <top>-50</top>
             <left>880</left>
-            <width>150</width>
+            <width>100</width>
             <aspectratio>keep</aspectratio>
             <texture>$INFO[Window().Property(seren.logo)]</texture>
         </control>


### PR DESCRIPTION
This fixes the logo sizes for certain windows:

Persistent background

Before - https://i.imgur.com/QFV011v.jpg
After - https://i.imgur.com/6Brybbi.jpg

Scraping screen

Before - https://i.imgur.com/JIT0XsF.jpg
After - https://i.imgur.com/lYOmEkd.jpg

Resolving screen

Before - https://i.imgur.com/l6QkePZ.jpg
After - https://i.imgur.com/68jCXHG.jpeg