### PR TITLE
Recolor provider count

### DIFF
--- a/resources/skins/Default/1080i/get_sources.xml
+++ b/resources/skins/Default/1080i/get_sources.xml
@@ -387,7 +387,7 @@
                 <aligny>center</aligny>
                 <width>auto</width>
                 <textcolor>FFDDDDDD</textcolor>
-                <label>Remaining Providers: $INFO[Window().Property(remaining_providers_count)]</label>
+                <label>Remaining Providers: [COLOR $INFO[Window().Property(settings.color)]]$INFO[Window().Property(remaining_providers_count)][/COLOR]</label>
                 <visible>Integer.IsGreaterOrEqual(Window().Property(remaining_providers_count),10)</visible>
             </control>
 


### PR DESCRIPTION
This recolors the provider count on scraping screen to the settings color:

Before - https://i.imgur.com/goghxI7.jpeg
After - https://i.imgur.com/P9LHem3.jpeg