### PR TITLE
Fix popup visibility issues

### DIFF
--- a/resources/skins/Default/1080i/playing_next.xml
+++ b/resources/skins/Default/1080i/playing_next.xml
@@ -81,7 +81,7 @@
                         <font>font_title_small</font>
                         <label>Next Episode in [COLOR $VAR[ColorHighlight]]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds...</label>
                         <textcolor>panel_fg_100</textcolor>
-                        <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
+                        <visible>!Integer.IsGreater(Player.TimeRemaining,180)</visible>
                     </control>
                     
                     <control type="label">
@@ -89,7 +89,7 @@
                         <font>font_title_small</font>
                         <label>Next Episode...</label>
                         <textcolor>panel_fg_100</textcolor>
-                        <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
+                        <visible>Integer.IsGreater(Player.TimeRemaining,180)</visible>
                     </control>
                     
                     <!-- Details -->
@@ -157,7 +157,7 @@
                             <param name="groupid" value="9011" />
                             <param name="label" value="Watch Now" />
                             <param name="icon" value="special://skin/extras/icons/play3.png" />
-                            <param name="visible" value="!Integer.IsGreater(Player.TimeRemaining,59)" />
+                            <param name="visible" value="!Integer.IsGreater(Player.TimeRemaining,180)" />
                             <onclick>SendClick(3012)</onclick>
                         </include>
                         

--- a/resources/skins/Default/1080i/still_watching.xml
+++ b/resources/skins/Default/1080i/still_watching.xml
@@ -81,7 +81,7 @@
                         <font>font_title_small</font>
                         <label>Next Episode in [COLOR $VAR[ColorHighlight]]$INFO[Player.TimeRemaining(ss),,][/COLOR] seconds...</label>
                         <textcolor>panel_fg_100</textcolor>
-                        <visible>!Integer.IsGreater(Player.TimeRemaining,59)</visible>
+                        <visible>!Integer.IsGreater(Player.TimeRemaining,180)</visible>
                     </control>
                     
                     <control type="label">
@@ -89,7 +89,7 @@
                         <font>font_title_small</font>
                         <label>Next Episode...</label>
                         <textcolor>panel_fg_100</textcolor>
-                        <visible>Integer.IsGreater(Player.TimeRemaining,59)</visible>
+                        <visible>Integer.IsGreater(Player.TimeRemaining,180)</visible>
                     </control>
                     
                     <!-- Details -->
@@ -157,7 +157,7 @@
                             <param name="groupid" value="9011" />
                             <param name="label" value="Continue Watching" />
                             <param name="icon" value="special://skin/extras/icons/play3.png" />
-                            <param name="visible" value="!Integer.IsGreater(Player.TimeRemaining,59)" />
+                            <param name="visible" value="!Integer.IsGreater(Player.TimeRemaining,180)" />
                             <onclick>SendClick(3012)</onclick>
                         </include>
                         

--- a/resources/skins/meta.json
+++ b/resources/skins/meta.json
@@ -1,6 +1,6 @@
 {
   "skin_name": "SerenMod-Full",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "author": "a4k",
   "update_directory": "https://www.github.com/SerpentDrago/SerenTheme-SerenMod-Full/zipball/master/",
   "remote_meta": "https://raw.githubusercontent.com/SerpentDrago/SerenTheme-SerenMod-Full/master/SerenMod-Full/resources/skins/meta.json"


### PR DESCRIPTION
This fixes #12 

I've increased the time for certain elements to become contextually visible according to the maximum time a user can set inside Seren for the PlayingNext SmartPlay popup (180 seconds).